### PR TITLE
IO tidy-up

### DIFF
--- a/fortran/geometry.F90
+++ b/fortran/geometry.F90
@@ -3,7 +3,8 @@ module geometry
 
   use globalVariables
   use grids
-  use HDF5
+  use readHDF5Input
+
 #include <finclude/petscsysdef.h>
 
 
@@ -13,10 +14,7 @@ module geometry
   PetscScalar :: Miller_A, Miller_x, Miller_QQ
   integer, parameter :: NThetaIntegral = 100
   integer :: HDF5Error
-  integer(HID_T) :: HDF5FileID, HDF5GroupID, HDF5DatasetID, parallelID
   character(len=100) :: HDF5Groupname
-  integer(HSIZE_T), dimension(1) :: arraydims1d
-  integer(HSIZE_T), dimension(2) :: arraydims2d
 
 
 contains
@@ -129,144 +127,23 @@ contains
        ! dIHatdpsi(Npsi)
 
     case (4)
-       ! Read arrays from hdf5 file
-       call h5fopen_f(trim(geometryFilename), H5F_ACC_RDONLY_F, HDF5FileID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening profiles input file"
-          stop
-       end if
-   
-
-       ! Get group for geometry data
-       write (HDF5Groupname,"(A4,I0,A6,I0)") "Npsi", Npsi, "Ntheta",Ntheta
-       call h5gopen_f(HDF5FileID, trim(HDF5Groupname), HDF5GroupID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening group for profiles with Npsi=",Npsi,", Ntheta=",Ntheta
-          stop
-       end if
-
-
-       ! Specify the dimensions of the arrays to read from the hdf5 file
-       arraydims2d(1) = Npsi
-       arraydims2d(2) = Ntheta
-
-       ! BHat
-       call h5dopen_f(HDF5GroupID, "BHat", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening BHat dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, BHat, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading BHat"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing BHat dataset"
-          stop
-       end if 
-
-       ! dBHatdpsi
-       call h5dopen_f(HDF5GroupID, "dBHatdpsi", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dBHatdpsi dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dBHatdpsi, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dBHatdpsi"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dBHatdpsi dataset"
-          stop
-       end if
-
-       ! dBHatdtheta
-       call h5dopen_f(HDF5GroupID, "dBHatdtheta", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dBHatdtheta dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dBHatdtheta, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dBHatdtheta"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dBHatdtheta dataset"
-          stop
-       end if
-
-       ! JHat
-       call h5dopen_f(HDF5GroupID, "JHat", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening JHat dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, JHat, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading JHat"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing JHat dataset"
-          stop
-       end if
-
-       !Read 1D IHat data
-       arraydims1d(1) = Npsi
        
-       ! IHat
-       call h5dopen_f(HDF5GroupID, "IHat", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening IHat dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, IHat, arraydims1d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading IHat"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing IHat dataset"
-          stop
-       end if
+       ! Create group name
+       write (HDF5Groupname,"(A4,I0,A6,I0)") "Npsi", Npsi, "Ntheta",Ntheta
 
-       ! dIHatdpsi
-       call h5dopen_f(HDF5GroupID, "dIHatdpsi", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dIHatdpsi dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dIHatdpsi, arraydims1d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dIHatdpsi"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dIHatdpsi dataset"
-          stop
-       end if
- 
-       call h5gclose_f(HDF5GroupID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing geometry group"
-          stop
-       end if
+       ! Open geometry input file
+       call openInputFile(geometryFilename, HDF5Groupname)
 
-       call h5fclose_f(HDF5FileID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing geometry file"
-          stop
-       end if
+       ! Read variables
+       call readVariable(BHat, "BHat")
+       call readVariable(dBHatdpsi, "dBHatdpsi")
+       call readVariable(dBHatdtheta, "dBHatdtheta")
+       call readVariable(JHat, "JHat")
+       call readVariable(IHat, "IHat")
+       call readVariable(dIHatdpsi, "dIHatdpsi")
 
+       ! Close geometry input file
+       call closeInputFile()
 
     case default
        print *,"Error! Invalid setting for geometryToUse"

--- a/fortran/makefile.depend
+++ b/fortran/makefile.depend
@@ -1,4 +1,5 @@
-OBJ_FILES = perfect.o xGrid.o geometry.o writeHDF5Output.o globalVariables.o scan.o readInput.o \
+OBJ_FILES = perfect.o xGrid.o geometry.o writeHDF5Output.o \
+	readHDF5Input.o globalVariables.o scan.o readInput.o \
 	polynomialDiffMatrices.o uniformDiffMatrices.o \
 	uniformInterpolationMatrix.o printToStdout.o \
 	profiles.o sparsify.o preallocateMatrix.o \
@@ -9,14 +10,14 @@ OBJ_FILES = perfect.o xGrid.o geometry.o writeHDF5Output.o globalVariables.o sca
 # Dependencies:
 DKEMatrices.o: globalVariables.o grids.o sparsify.o
 DKERhs.o: globalVariables.o grids.o
-geometry.o: globalVariables.o grids.o
+geometry.o: globalVariables.o grids.o readHDF5Input.o
 grids.o: globalVariables.o polynomialDiffMatrices.o printToStdout.o xGrid.o
 matlabOutput.o: globalVariables.o DKEMatrices.o DKERhs.o
 moments.o: globalVariables.o grids.o
 perfect.o: globalVariables.o geometry.o writeHDF5Output.o printToStdout.o solveDKE.o readInput.o scan.o
 preallocateMatrix.o: globalVariables.o
 printToStdout.o: globalVariables.o
-profiles.o: globalVariables.o grids.o
+profiles.o: globalVariables.o grids.o readHDF5Input.o
 readInput.o: globalVariables.o
 scan.o: globalVariables.o
 solveDKE.o: DKEMatrices.o DKERhs.o globalVariables.o geometry.o profiles.o sparsify.o grids.o moments.o matlabOutput.o

--- a/fortran/perfect.F90
+++ b/fortran/perfect.F90
@@ -70,7 +70,7 @@ program perfect
 
      call openOutputFile()
      call allocateArraysForSingleRun()
-     call createHDF5Structures()
+     call setupOutput()
      call solveDKEMain()
      call writeRunToOutputFile(1)
 
@@ -90,7 +90,7 @@ program perfect
      end if
      call setMPICommunicatorsForScan()
      call openOutputFile()
-     call createHDF5Structures()
+     call setupOutput()
      call PetscTime(time1, ierr)
 
      do runNum = minScanUnit,maxScanUnit

--- a/fortran/profiles.F90
+++ b/fortran/profiles.F90
@@ -6,7 +6,7 @@ module profiles
 
   use globalVariables
   use grids
-  use HDF5
+  use readHDF5Input
 
   implicit none
 
@@ -44,11 +44,7 @@ contains
     PetscScalar, dimension(:,:), allocatable :: temp_d2dpsi2
     PetscScalar, allocatable, dimension(:,:) :: TInterpolationRowVec
     PetscScalar, dimension(1) :: TAtPsiMid
-    integer :: HDF5Error
-    integer(HID_T) :: HDF5FileID, HDF5GroupID, HDF5DatasetID, parallelID
     character(len=100) :: HDF5Groupname
-    integer(HSIZE_T), dimension(1) :: arraydims1d
-    integer(HSIZE_T), dimension(2) :: arraydims2d
 
     allocate(PhiHat(Npsi))
     allocate(dPhiHatdpsi(Npsi))
@@ -62,176 +58,30 @@ contains
     if (profilesScheme .eq. 7) then
        ! Read in profiles from file
 
-       ! Open input file
+       ! Check profilesFilename is set
        if (.not. len(profilesFilename)>=0) then
           print *,"If profilesScheme==7 then profilesFilename must be set."
           stop
        end if
-       call h5fopen_f(trim(profilesFilename), H5F_ACC_RDONLY_F, HDF5FileID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening profiles input file"
-          stop
-       end if
        
-       ! Get group for radial profiles
+       ! Create groupname to be read
        write (HDF5Groupname,"(A4,I0)") "Npsi", Npsi
-       call h5gopen_f(HDF5FileID, trim(HDF5Groupname), HDF5GroupID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening group for profiles with Npsi=",Npsi
-          stop
-       end if
 
-       ! Read in profiles from datasets in the group that was just opened
-       ! PhiHat
-       arraydims1d(1) = Npsi
-       call h5dopen_f(HDF5GroupID, "PhiHat", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening PhiHat dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, PhiHat, arraydims1d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading PhiHat"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing PhiHat dataset"
-          stop
-       end if
+       ! Open input file
+       call openInputFile(profilesFilename,HDF5Groupname)
 
-       ! dPhiHatdpsi
-       call h5dopen_f(HDF5GroupID, "dPhiHatdpsi", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dPhiHatdpsi dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dPhiHatdpsi, arraydims1d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dPhiHatdpsi"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dPhiHatdpsi dataset"
-          stop
-       end if
-
-       arraydims2d(1) = numSpecies
-       arraydims2d(2) = Npsi
-       ! THats
-       call h5dopen_f(HDF5GroupID, "THats", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening THats dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, THats, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading THats"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing THats dataset"
-          stop
-       end if
-
-       ! dTHatdpsis
-       call h5dopen_f(HDF5GroupID, "dTHatdpsis", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dTHatdpsis dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dTHatdpsis, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dTHatdpsis"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dTHatdpsis dataset"
-          stop
-       end if
-
-       ! nHats
-       call h5dopen_f(HDF5GroupID, "nHats", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening nHats dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, nHats, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading nHats"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing nHats dataset"
-          stop
-       end if
-
-       ! dnHatdpsis
-       call h5dopen_f(HDF5GroupID, "dnHatdpsis", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening dnHatdpsis dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, dnHatdpsis, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading dnHatdpsis"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing dnHatdpsis dataset"
-          stop
-       end if
-
-       ! etaHats
-       call h5dopen_f(HDF5GroupID, "etaHats", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening etaHats dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, etaHats, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading etaHats"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing etaHats dataset"
-          stop
-       end if
-
-       ! detaHatdpsis
-       call h5dopen_f(HDF5GroupID, "detaHatdpsis", HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error opening detaHatdpsis dataset"
-          stop
-       end if
-       call h5dread_f(HDF5DatasetID, H5T_NATIVE_DOUBLE, detaHatdpsis, arraydims2d, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error reading detaHatdpsis"
-          stop
-       end if
-       call h5dclose_f(HDF5DatasetID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing detaHatdpsis dataset"
-          stop
-       end if
-
-       call h5gclose_f(HDF5GroupID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing profiles group"
-          stop
-       end if
-
-       call h5fclose_f(HDF5FileID, HDF5Error)
-       if (HDF5Error < 0) then
-          print *,"Error closing profiles file"
-          stop
-       end if
+       ! Read in profiles
+       call readVariable(PhiHat, "PhiHat")
+       call readVariable(dPhiHatdpsi, "dPhiHatdpsi")
+       call readVariable(THats, "THats")
+       call readVariable(dTHatdpsis, "dTHatdpsis")
+       call readVariable(nHats, "nHats")
+       call readVariable(dnHatdpsis, "dnHatdpsis")
+       call readVariable(etaHats, "etaHats")
+       call readVariable(detaHatdpsis, "detaHatdpsis")
+       
+       ! Close input file
+       call closeInputFile()
 
     else
 

--- a/fortran/readHDF5Input.F90
+++ b/fortran/readHDF5Input.F90
@@ -1,0 +1,194 @@
+module readHDF5Input
+
+  use HDF5
+
+  implicit none
+
+#include <finclude/petscsysdef.h>
+
+  interface readVariable
+    module procedure readVariable_integer
+    module procedure readVariable_scalar
+    module procedure readVariable_1d
+    module procedure readVariable_2d
+  end interface readVariable
+
+  integer(HID_T), private :: fileID, groupID
+
+contains
+
+  subroutine openInputFile(fileName, groupName)
+
+    character(len=*), intent(in) :: fileName, groupName
+    integer :: HDF5Error
+
+    ! Open input file
+    call h5fopen_f(trim(fileName), H5F_ACC_RDONLY_F, fileID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening file:", fileName
+      stop
+    end if
+       
+    ! Open group
+    call h5gopen_f(fileID, trim(groupName), groupID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening group:",groupName
+      stop
+    end if
+
+  end subroutine openInputFile
+
+  subroutine closeInputFile()
+
+    integer :: HDF5Error
+
+    ! Close the group
+    call h5gclose_f(groupID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing input group"
+      stop
+    end if
+
+    ! Close the file
+    call h5fclose_f(fileID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing input file"
+      stop
+    end if
+
+  end subroutine closeInputFile
+
+  subroutine readVariable_integer(variable,varname)
+
+    integer, intent(inout) :: variable
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dataSetID
+    integer(HSIZE_T), dimension(0) :: dimensions
+    integer :: HDF5Error
+
+    dimensions = shape(variable)
+
+    ! Open Dataset
+    call h5dopen_f(groupID, varname, dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening dataset for variable:",varname
+      stop
+    end if
+    
+    ! Read variable
+    call h5dread_f(dataSetID, H5T_NATIVE_INTEGER, variable, dimensions, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error reading variable:",varname
+      stop
+    end if
+
+    ! Close Dataset
+    call h5dclose_f(dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing dataset for variable:",varname
+      stop
+    end if
+
+  end subroutine readVariable_integer
+
+  subroutine readVariable_scalar(variable,varname)
+
+    PetscScalar, intent(inout) :: variable
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dataSetID
+    integer(HSIZE_T), dimension(0) :: dimensions
+    integer :: HDF5Error
+
+    dimensions = shape(variable)
+
+    ! Open Dataset
+    call h5dopen_f(groupID, varname, dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening dataset for variable:",varname
+      stop
+    end if
+    
+    ! Read variable
+    call h5dread_f(dataSetID, H5T_NATIVE_DOUBLE, variable, dimensions, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error reading variable:",varname
+      stop
+    end if
+
+    ! Close Dataset
+    call h5dclose_f(dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing dataset for variable:",varname
+      stop
+    end if
+
+  end subroutine readVariable_scalar
+
+  subroutine readVariable_1d(variable,varname)
+
+    PetscScalar, intent(inout), dimension(:), allocatable :: variable
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dataSetID
+    integer(HSIZE_T), dimension(1) :: dimensions
+    integer :: HDF5Error
+
+    dimensions = shape(variable)
+
+    ! Open Dataset
+    call h5dopen_f(groupID, varname, dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening dataset for variable:",varname
+      stop
+    end if
+    
+    ! Read variable
+    call h5dread_f(dataSetID, H5T_NATIVE_DOUBLE, variable, dimensions, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error reading variable:",varname
+      stop
+    end if
+
+    ! Close Dataset
+    call h5dclose_f(dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing dataset for variable:",varname
+      stop
+    end if
+
+  end subroutine readVariable_1d
+
+  subroutine readVariable_2d(variable,varname)
+
+    PetscScalar, intent(inout), dimension(:,:), allocatable :: variable
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dataSetID
+    integer(HSIZE_T), dimension(2) :: dimensions
+    integer :: HDF5Error
+
+    dimensions = shape(variable)
+
+    ! Open Dataset
+    call h5dopen_f(groupID, varname, dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error opening dataset for variable:",varname
+      stop
+    end if
+    
+    ! Read variable
+    call h5dread_f(dataSetID, H5T_NATIVE_DOUBLE, variable, dimensions, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error reading variable:",varname
+      stop
+    end if
+
+    ! Close Dataset
+    call h5dclose_f(dataSetID, HDF5Error)
+    if (HDF5Error < 0) then
+      print *,"Error closing dataset for variable:",varname
+      stop
+    end if
+
+  end subroutine readVariable_2d
+
+end module readHDF5Input
+

--- a/fortran/writeHDF5Output.F90
+++ b/fortran/writeHDF5Output.F90
@@ -2,163 +2,42 @@
 
 module writeHDF5Output
 
-  use globalVariables
-  use scan
-  use petscsysdef
-  use HDF5
+use globalVariables
+use scan
+use petscsysdef
+use HDF5
 
-  implicit none
+implicit none
 
 #include <finclude/petscsysdef.h>
 
-  integer, private :: HDF5Error
-  integer(HID_T), private :: HDF5FileID, parallelID, dspaceIDForScalar
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForSpecies
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForProfile
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForSpeciesProfile
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForTheta
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForThetaPsi
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForSpeciesThetaPsi
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForXUniform
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForXiUniform
-  integer(HID_T), dimension(:), allocatable, private :: dspaceIDForSpeciesPsiXUniformXiUniform
-  integer(HID_T), dimension(:), allocatable, private :: groupIDs
+integer, private :: HDF5Error
+integer(HID_T), private :: HDF5FileID, parallelID
+integer(HID_T), dimension(:), allocatable, private :: groupIDs
+interface writeVariable
+  module procedure writeVariable_integer
+  module procedure writeVariable_scalar
+  module procedure writeVariable_1d
+  module procedure writeVariable_2d
+  module procedure writeVariable_3d
+  module procedure writeVariable_4d
+  module procedure writeVariable_5d
+end interface writeVariable
 
-  integer(HID_T), private :: dsetID_programMode
-
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_charges
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_masses
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_scalarTHats
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_scalarNHats
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_NpsiPerDiameter
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Npsi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_psiDiameter
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_widthExtender
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Nspecies
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Ntheta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Nxi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_NL
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Nx
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_NxPotentialsPerVth
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_xMax
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_xMaxForDistribution
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_solverTolerance
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Delta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_omega
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_psiAHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_nu_r
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_Miller_q
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_epsil
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_psi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_theta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_JHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_BHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dBHatdpsi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dBHatdtheta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_IHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dIHatdpsi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_PhiHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dPhiHatdpsi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_THats
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dTHatdpsis
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_nHats
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dnHatdpsis
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_etaHats
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_detaHatdpsis
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_elapsedTime
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_sourcePoloidalVariation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_particleSourceProfile
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_heatSourceProfile
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_VPrimeHat
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_FSABHat2
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_U
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_r
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_densityPerturbation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_flow
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kPar
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_pressurePerturbation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_particleFluxBeforeThetaIntegral
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_momentumFluxBeforeThetaIntegral
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_heatFluxBeforeThetaIntegral
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_FSADensityPerturbation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_flowOutboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_flowInboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_FSABFlow
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kParOutboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kParInboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_FSAKPar
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_FSAPressurePerturbation
-!  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_LHSOfKParEquation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_particleFlux
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_momentumFlux
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_heatFlux
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_makeLocalApproximation
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_useIterativeSolver
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_didItConverge
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_psiDerivativeScheme
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_thetaDerivativeScheme
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_xDerivativeScheme
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaWith3PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaWith5PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaOutboardWith3PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaOutboardWith5PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaInboardWith3PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_kThetaInboardWith5PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_PhiTermInKTheta
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_pPerpTermInKThetaBeforePsiDerivative
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_pPerpTermInKThetaWith3PointStencil
-!!$  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_pPerpTermInKThetaWith5PointStencil
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_nuPrimeProfile
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_nuStarProfile
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_deltaN
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_deltaT
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_deltaEta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_desiredU
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_desiredFWHMInRhoTheta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_exponent
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_dTHatdpsiScalar
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_detaHatdpsiScalar
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_setTPrimeToBalanceHeatFlux
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_includeddpsiTerm
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_species
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_x
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_x_min_L
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_xi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_theta
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_preconditioner_psi
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_layout
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_NxUniform
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_NxiUniform
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_xUniform
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_xiUniform
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_thetaIndexForOutboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_deltaFOutboard
-  integer(HID_T), dimension(:), allocatable, private :: dsetIDs_fullFOutboard
-
-  integer(HSIZE_T), dimension(1), parameter, private :: dimForScalar = 1
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForSpecies
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForProfile
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForSpeciesProfile
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForTheta
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForThetaPsi
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForSpeciesThetaPsi
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForXUniform
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForXiUniform
-  integer(HSIZE_T), dimension(:,:), allocatable, private :: dimForSpeciesPsiXUniformXiUniform
-
-  ! Stuff for writing debugging output:
-  integer(HID_T), private :: HDF5DebugFileID
-  interface writeDebugArray
-    module procedure writeDebugArray_scalar
-    module procedure writeDebugArray_1d
-    module procedure writeDebugArray_2d
-    module procedure writeDebugArray_3d
-    module procedure writeDebugArray_4d
-  end interface writeDebugArray
+! Stuff for writing debugging output:
+integer(HID_T), private :: HDF5DebugFileID
+interface writeDebugArray
+  module procedure writeDebugArray_scalar
+  module procedure writeDebugArray_1d
+  module procedure writeDebugArray_2d
+  module procedure writeDebugArray_3d
+  module procedure writeDebugArray_4d
+  module procedure writeDebugArray_5d
+end interface writeDebugArray
 
 contains
 
-  ! -----------------------------------------------------------------------------------
+! -----------------------------------------------------------------------------------
 
   subroutine openOutputFile()
 
@@ -195,7 +74,7 @@ contains
 
   ! -----------------------------------------------------------------------------------
 
-  subroutine createHDF5Structures()
+  subroutine setupOutput()
 
     implicit none
 
@@ -209,524 +88,17 @@ contains
 #endif
        allocate(groupIDs(numRunsInScan))
 
-       allocate(dsetIDs_charges(numRunsInScan))
-       allocate(dsetIDs_masses(numRunsInScan))
-       allocate(dsetIDs_scalarTHats(numRunsInScan))
-       allocate(dsetIDs_scalarNHats(numRunsInScan))
-       allocate(dsetIDs_NpsiPerDiameter(numRunsInScan))
-       allocate(dsetIDs_Npsi(numRunsInScan))
-       allocate(dsetIDs_psiDiameter(numRunsInScan))
-       allocate(dsetIDs_widthExtender(numRunsInScan))
-       allocate(dsetIDs_Nspecies(numRunsInScan))
-       allocate(dsetIDs_Ntheta(numRunsInScan))
-       allocate(dsetIDs_Nxi(numRunsInScan))
-       allocate(dsetIDs_NL(numRunsInScan))
-       allocate(dsetIDs_Nx(numRunsInScan))
-       allocate(dsetIDs_NxPotentialsPerVth(numRunsInScan))
-       allocate(dsetIDs_xMax(numRunsInScan))
-       allocate(dsetIDs_xMaxForDistribution(numRunsInScan))
-       allocate(dsetIDs_solverTolerance(numRunsInScan))
-       allocate(dsetIDs_Delta(numRunsInScan))
-       allocate(dsetIDs_omega(numRunsInScan))
-       allocate(dsetIDs_psiAHat(numRunsInScan))
-       allocate(dsetIDs_nu_r(numRunsInScan))
-       allocate(dsetIDs_Miller_q(numRunsInScan))
-       allocate(dsetIDs_epsil(numRunsInScan))
-       allocate(dsetIDs_psi(numRunsInScan))
-       allocate(dsetIDs_theta(numRunsInScan))
-       allocate(dsetIDs_JHat(numRunsInScan))
-       allocate(dsetIDs_BHat(numRunsInScan))
-       allocate(dsetIDs_dBHatdpsi(numRunsInScan))
-       allocate(dsetIDs_dBHatdtheta(numRunsInScan))
-       allocate(dsetIDs_IHat(numRunsInScan))
-       allocate(dsetIDs_dIHatdpsi(numRunsInScan))
-       allocate(dsetIDs_PhiHat(numRunsInScan))
-       allocate(dsetIDs_dPhiHatdpsi(numRunsInScan))
-       allocate(dsetIDs_THats(numRunsInScan))
-       allocate(dsetIDs_dTHatdpsis(numRunsInScan))
-       allocate(dsetIDs_nHats(numRunsInScan))
-       allocate(dsetIDs_dnHatdpsis(numRunsInScan))
-       allocate(dsetIDs_etaHats(numRunsInScan))
-       allocate(dsetIDs_detaHatdpsis(numRunsInScan))
-       allocate(dsetIDs_elapsedTime(numRunsInScan))
-       allocate(dsetIDs_sourcePoloidalVariation(numRunsInScan))
-       allocate(dsetIDs_particleSourceProfile(numRunsInScan))
-       allocate(dsetIDs_heatSourceProfile(numRunsInScan))
-       allocate(dsetIDs_VPrimeHat(numRunsInScan))
-       allocate(dsetIDs_FSABHat2(numRunsInScan))
-       allocate(dsetIDs_U(numRunsInScan))
-       allocate(dsetIDs_r(numRunsInScan))
-       allocate(dsetIDs_densityPerturbation(numRunsInScan))
-       allocate(dsetIDs_flow(numRunsInScan))
-       allocate(dsetIDs_kPar(numRunsInScan))
-       allocate(dsetIDs_pressurePerturbation(numRunsInScan))
-       allocate(dsetIDs_particleFluxBeforeThetaIntegral(numRunsInScan))
-       allocate(dsetIDs_momentumFluxBeforeThetaIntegral(numRunsInScan))
-       allocate(dsetIDs_heatFluxBeforeThetaIntegral(numRunsInScan))
-       allocate(dsetIDs_FSADensityPerturbation(numRunsInScan))
-       allocate(dsetIDs_flowOutboard(numRunsInScan))
-       allocate(dsetIDs_flowInboard(numRunsInScan))
-       allocate(dsetIDs_FSABFlow(numRunsInScan))
-       allocate(dsetIDs_kParOutboard(numRunsInScan))
-       allocate(dsetIDs_kParInboard(numRunsInScan))
-       allocate(dsetIDs_FSAKPar(numRunsInScan))
-!       allocate(dsetIDs_LHSOfKParEquation(numRunsInScan))
-       allocate(dsetIDs_FSAPressurePerturbation(numRunsInScan))
-       allocate(dsetIDs_particleFlux(numRunsInScan))
-       allocate(dsetIDs_momentumFlux(numRunsInScan))
-       allocate(dsetIDs_heatFlux(numRunsInScan))
-       allocate(dsetIDs_makeLocalApproximation(numRunsInScan))
-       allocate(dsetIDs_useIterativeSolver(numRunsInScan))
-       allocate(dsetIDs_didItConverge(numRunsInScan))
-       allocate(dsetIDs_psiDerivativeScheme(numRunsInScan))
-       allocate(dsetIDs_thetaDerivativeScheme(numRunsInScan))
-       allocate(dsetIDs_xDerivativeScheme(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaWith3PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaWith5PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaOutboardWith3PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaOutboardWith5PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaInboardWith3PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_kThetaInboardWith5PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_PhiTermInKTheta(numRunsInScan))
-!!$       allocate(dsetIDs_pPerpTermInKThetaBeforePsiDerivative(numRunsInScan))
-!!$       allocate(dsetIDs_pPerpTermInKThetaWith3PointStencil(numRunsInScan))
-!!$       allocate(dsetIDs_pPerpTermInKThetaWith5PointStencil(numRunsInScan))
-       allocate(dsetIDs_nuPrimeProfile(numRunsInScan))
-       allocate(dsetIDs_nuStarProfile(numRunsInScan))
-       allocate(dsetIDs_deltaN(numRunsInScan))
-       allocate(dsetIDs_deltaT(numRunsInScan))
-       allocate(dsetIDs_deltaEta(numRunsInScan))
-       allocate(dsetIDs_desiredU(numRunsInScan))
-       allocate(dsetIDs_desiredFWHMInRhoTheta(numRunsInScan))
-       allocate(dsetIDs_exponent(numRunsInScan))
-       allocate(dsetIDs_dTHatdpsiScalar(numRunsInScan))
-       allocate(dsetIDs_detaHatdpsiScalar(numRunsInScan))
-       allocate(dsetIDs_setTPrimeToBalanceHeatFlux(numRunsInScan))
-       allocate(dsetIDs_includeddpsiTerm(numRunsInScan))
-       allocate(dsetIDs_preconditioner_species(numRunsInScan))
-       allocate(dsetIDs_preconditioner_x(numRunsInScan))
-       allocate(dsetIDs_preconditioner_x_min_L(numRunsInScan))
-       allocate(dsetIDs_preconditioner_xi(numRunsInScan))
-       allocate(dsetIDs_preconditioner_theta(numRunsInScan))
-       allocate(dsetIDs_preconditioner_psi(numRunsInScan))
-       allocate(dsetIDs_layout(numRunsInScan))
-       allocate(dsetIDs_NxUniform(numRunsInScan))
-       allocate(dsetIDs_NxiUniform(numRunsInScan))
-       allocate(dsetIDs_xUniform(numRunsInScan))
-       allocate(dsetIDs_xiUniform(numRunsInScan))
-       allocate(dsetIDs_thetaIndexForOutboard(numRunsInScan))
-       allocate(dsetIDs_deltaFOutboard(numRunsInScan))
-       allocate(dsetIDs_fullFOutboard(numRunsInScan))
-
-       allocate(dspaceIDForSpecies(numRunsInScan))
-       allocate(dspaceIDForProfile(numRunsInScan))
-       allocate(dspaceIDForSpeciesProfile(numRunsInScan))
-       allocate(dspaceIDForTheta(numRunsInScan))
-       allocate(dspaceIDForThetaPsi(numRunsInScan))
-       allocate(dspaceIDForSpeciesThetaPsi(numRunsInScan))
-       allocate(dspaceIDForXUniform(numRunsInScan))
-       allocate(dspaceIDForXiUniform(numRunsInScan))
-       allocate(dspaceIDForSpeciesPsiXUniformXiUniform(numRunsInScan))
-
-       allocate(dimForSpecies(numRunsInScan,1))
-       allocate(dimForProfile(numRunsInScan,1))
-       allocate(dimForSpeciesProfile(numRunsInScan,2))
-       allocate(dimForTheta(numRunsInScan,1))
-       allocate(dimForThetaPsi(numRunsInScan,2))
-       allocate(dimForSpeciesThetaPsi(numRunsInScan,3))
-       allocate(dimForXUniform(numRunsInScan,1))
-       allocate(dimForXiUniform(numRunsInScan,1))
-       allocate(dimForSpeciesPsiXUniformXiUniform(numRunsInScan,4))
-
-       ! Create a dataspace for storing single numbers:
-       rank = 0
-       call h5screate_simple_f(rank, dimForScalar, dspaceIDForScalar, HDF5Error)
-
        ! Save programMode in the file:
-       call h5dcreate_f(HDF5FileID, "programMode", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-            dsetID_programMode, HDF5Error)
-       if (masterProc) then
-          call h5dwrite_f(dsetID_programMode, H5T_NATIVE_INTEGER, programMode, dimForScalar, HDF5Error)
-       end if
-       call h5dclose_f(dsetID_programMode, HDF5Error)
+       call writeIntegerNoGroup(programMode, "programMode")
 
        do i=1,numRunsInScan
           ! Create a group to hold all data for the run:
           write (groupName, "(a, i3)") "run",i
           call h5gcreate_f(HDF5FileID, groupName, groupIDs(i), HDF5Error)
-
-          ! Create dataspaces that depend on resolution parameters:
-          rank = 1
-          dimForProfile(i,1)=NpsisForScan(i)
-          call h5screate_simple_f(rank, dimForProfile(i,:), dspaceIDForProfile(i), HDF5Error)
-
-          dimForTheta(i,1)=NthetasForScan(i)
-          call h5screate_simple_f(rank, dimForTheta(i,:), dspaceIDForTheta(i), HDF5Error)
-
-          dimForSpecies(i,1)=numSpecies
-          call h5screate_simple_f(rank, dimForSpecies(i,:), dspaceIDForSpecies(i), HDF5Error)
-
-          dimForXUniform(i,1)=NxUniform
-          call h5screate_simple_f(rank, dimForXUniform(i,:), dspaceIDForXUniform(i), HDF5Error)
-
-          dimForXiUniform(i,1)=NxiUniform
-          call h5screate_simple_f(rank, dimForXiUniform(i,:), dspaceIDForXiUniform(i), HDF5Error)
-
-          rank = 2
-          dimForSpeciesProfile(i,1)=numSpecies
-          dimForSpeciesProfile(i,2)=NpsisForScan(i)
-          call h5screate_simple_f(rank, dimForSpeciesProfile(i,:), dspaceIDForSpeciesProfile(i), HDF5Error)
-
-          rank = 2
-          dimForThetaPsi(i,1)=NthetasForScan(i)
-          dimForThetaPsi(i,2)=NpsisForScan(i)
-          call h5screate_simple_f(rank, dimForThetaPsi(i,:), dspaceIDForThetaPsi(i), HDF5Error)
-
-          rank = 3
-          dimForSpeciesThetaPsi(i,1)=numSpecies
-          dimForSpeciesThetaPsi(i,2)=NthetasForScan(i)
-          dimForSpeciesThetaPsi(i,3)=NpsisForScan(i)
-          call h5screate_simple_f(rank, dimForSpeciesThetaPsi(i,:), dspaceIDForSpeciesThetaPsi(i), HDF5Error)
-
-          rank = 4
-          dimForSpeciesPsiXUniformXiUniform(i,1)=numSpecies
-          dimForSpeciesPsiXUniformXiUniform(i,2)=NpsisForScan(i)
-          dimForSpeciesPsiXUniformXiUniform(i,3)=NxUniform
-          dimForSpeciesPsiXUniformXiUniform(i,4)=NxiUniform
-          call h5screate_simple_f(rank, dimForSpeciesPsiXUniformXiUniform(i,:), &
-               dspaceIDForSpeciesPsiXUniformXiUniform(i), HDF5Error)
-
-          ! Create datasets for each quantity in each run:
-          call h5dcreate_f(groupIDs(i), "charges", H5T_NATIVE_DOUBLE, dspaceIDForSpecies(i), &
-               dsetIDs_charges(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "masses", H5T_NATIVE_DOUBLE, dspaceIDForSpecies(i), &
-               dsetIDs_masses(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "scalarTHats", H5T_NATIVE_DOUBLE, dspaceIDForSpecies(i), &
-               dsetIDs_scalarTHats(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "scalarNHats", H5T_NATIVE_DOUBLE, dspaceIDForSpecies(i), &
-               dsetIDs_scalarNHats(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "NpsiPerDiameter", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_NpsiPerDiameter(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Npsi", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_Npsi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "psiDiameter", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_psiDiameter(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "widthExtender", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_widthExtender(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Nspecies", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_Nspecies(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Ntheta", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_Ntheta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Nxi", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_Nxi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "NL", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_NL(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Nx", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_Nx(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "NxPotentialsPerVth", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_NxPotentialsPerVth(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "xMax", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_xMax(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "xMaxForDistribution", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_xMaxForDistribution(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "solverTolerance", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_solverTolerance(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Delta", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_Delta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "omega", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_omega(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "psiAHat", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_psiAHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "nu_r", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_nu_r(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "Miller_q", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_Miller_q(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "epsil", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_epsil(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "psi", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_psi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "theta", H5T_NATIVE_DOUBLE, dspaceIDForTheta(i), &
-               dsetIDs_theta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "JHat", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-               dsetIDs_JHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "BHat", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-               dsetIDs_BHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(BHat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-               dsetIDs_dBHatdpsi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(BHat)d(theta)", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-               dsetIDs_dBHatdtheta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "IHat", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_IHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(IHat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_dIHatdpsi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "PhiHat", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_PhiHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(PhiHat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_dPhiHatdpsi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "THat", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_THats(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(THat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_dTHatdpsis(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "nHat", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_nHats(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(nHat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_dnHatdpsis(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "etaHat", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_etaHats(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "d(etaHat)d(psi)", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_detaHatdpsis(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "elapsed time (s)", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_elapsedTime(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "sourcePoloidalVariation", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_sourcePoloidalVariation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "particleSourceProfile", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_particleSourceProfile(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "heatSourceProfile", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_heatSourceProfile(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "VPrimeHat", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_VPrimeHat(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "FSABHat2", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-               dsetIDs_FSABHat2(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "U", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_U(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "r", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_r(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "densityPerturbation", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_densityPerturbation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "flow", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_flow(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "kPar", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_kPar(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "pressurePerturbation", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_pressurePerturbation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "particleFluxBeforeThetaIntegral", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_particleFluxBeforeThetaIntegral(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "momentumFluxBeforeThetaIntegral", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_momentumFluxBeforeThetaIntegral(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "heatFluxBeforeThetaIntegral", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesThetaPsi(i), &
-               dsetIDs_heatFluxBeforeThetaIntegral(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "FSADensityPerturbation", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_FSADensityPerturbation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "flowOutboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_flowOutboard(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "flowInboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_flowInboard(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "FSABFlow", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_FSABFlow(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "kParOutboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_kParOutboard(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "kParInboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_kParInboard(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "FSAKPar", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_FSAKPar(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "FSAPressurePerturbation", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_FSAPressurePerturbation(i), HDF5Error)
-
-!!$          call h5dcreate_f(groupIDs(i), "LHSOfKParEquation", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-!!$               dsetIDs_LHSOfKParEquation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "particleFlux", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_particleFlux(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "momentumFlux", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_momentumFlux(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "heatFlux", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_heatFlux(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "makeLocalApproximation", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_makeLocalApproximation(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "useIterativeSolver", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_useIterativeSolver(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "didItConverge", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_didItConverge(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "psiDerivativeScheme", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_psiDerivativeScheme(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "thetaDerivativeScheme", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_thetaDerivativeScheme(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "xDerivativeScheme", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_xDerivativeScheme(i), HDF5Error)
-
-!!$          call h5dcreate_f(groupIDs(i), "kThetaWith3PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_kThetaWith3PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "kThetaWith5PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_kThetaWith5PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "kThetaOutboardWith3PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-!!$               dsetIDs_kThetaOutboardWith3PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "kThetaOutboardWith5PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-!!$               dsetIDs_kThetaOutboardWith5PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "kThetaInboardWith3PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-!!$               dsetIDs_kThetaInboardWith3PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "kThetaInboardWith5PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForProfile(i), &
-!!$               dsetIDs_kThetaInboardWith5PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "PhiTermInKTheta", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_PhiTermInKTheta(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "pPerpTermInKThetaBeforePsiDerivative", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_pPerpTermInKThetaBeforePsiDerivative(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "pPerpTermInKThetaWith3PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_pPerpTermInKThetaWith3PointStencil(i), HDF5Error)
-!!$
-!!$          call h5dcreate_f(groupIDs(i), "pPerpTermInKThetaWith5PointStencil", H5T_NATIVE_DOUBLE, dspaceIDForThetaPsi(i), &
-!!$               dsetIDs_pPerpTermInKThetaWith5PointStencil(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "nuPrimeProfile", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_nuPrimeProfile(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "nuStarProfile", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_nuStarProfile(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "deltaN", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_deltaN(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "deltaT", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_deltaT(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "deltaEta", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesProfile(i), &
-               dsetIDs_deltaEta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "desiredU", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_desiredU(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "desiredFWHMInRhoTheta", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_desiredFWHMInRhoTheta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "dTHatdpsiScalar", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_dTHatdpsiScalar(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "detaHatdpsiScalar", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_detaHatdpsiScalar(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "exponent", H5T_NATIVE_DOUBLE, dspaceIDForScalar, &
-               dsetIDs_exponent(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "setTPrimeToBalanceHeatFlux", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_setTPrimeToBalanceHeatFlux(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "includeddpsiTerm", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_includeddpsiTerm(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_species", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_species(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_x", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_x(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_x_min_L", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_x_min_L(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_xi", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_xi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_theta", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_theta(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "preconditioner_psi", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_preconditioner_psi(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "layout", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_layout(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "NxUniform", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_NxUniform(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "NxiUniform", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_NxiUniform(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "xUniform", H5T_NATIVE_DOUBLE, dspaceIDForXUniform(i), &
-               dsetIDs_xUniform(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "xiUniform", H5T_NATIVE_DOUBLE, dspaceIDForXiUniform(i), &
-               dsetIDs_xiUniform(i), HDF5Error)
-
-          call h5dcreate_f(groupIDs(i), "thetaIndexForOutboard", H5T_NATIVE_INTEGER, dspaceIDForScalar, &
-               dsetIDs_thetaIndexForOutboard(i), HDF5Error)
-
-          if (outputScheme > 1) then
-             call h5dcreate_f(groupIDs(i), "deltaFOutboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesPsiXUniformXiUniform(i), &
-                  dsetIDs_deltaFOutboard(i), HDF5Error)
-
-             call h5dcreate_f(groupIDs(i), "fullFOutboard", H5T_NATIVE_DOUBLE, dspaceIDForSpeciesPsiXUniformXiUniform(i), &
-                  dsetIDs_fullFOutboard(i), HDF5Error)
-          end if
-
        end do
     end if
 
-  end subroutine createHDF5Structures
+  end subroutine setupOutput
 
   ! -----------------------------------------------------------------------------------
 
@@ -737,358 +109,143 @@ contains
     integer, intent(in) :: runNum
     integer :: temp
 
-    if (outputScheme > 0 .and. masterProcInSubComm) then
-
-       call h5dwrite_f(dsetIDs_charges(runNum), H5T_NATIVE_DOUBLE, &
-            charges, dimForSpecies(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_masses(runNum), H5T_NATIVE_DOUBLE, &
-            masses, dimForSpecies(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_scalarTHats(runNum), H5T_NATIVE_DOUBLE, &
-            scalarTHats, dimForSpecies(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_scalarNHats(runNum), H5T_NATIVE_DOUBLE, &
-            scalarNHats, dimForSpecies(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_NpsiPerDiameter(runNum), H5T_NATIVE_DOUBLE, &
-            NpsiPerDiameter, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Npsi(runNum), H5T_NATIVE_INTEGER, &
-            Npsi, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_psiDiameter(runNum), H5T_NATIVE_DOUBLE, &
-            psiDiameter, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_widthExtender(runNum), H5T_NATIVE_DOUBLE, &
-            widthExtender, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Nspecies(runNum), H5T_NATIVE_INTEGER, &
-            numSpecies, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Ntheta(runNum), H5T_NATIVE_INTEGER, &
-            Ntheta, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Nxi(runNum), H5T_NATIVE_INTEGER, &
-            Nxi, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_NL(runNum), H5T_NATIVE_INTEGER, &
-            NL, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Nx(runNum), H5T_NATIVE_INTEGER, &
-            Nx, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_NxPotentialsPerVth(runNum), H5T_NATIVE_DOUBLE, &
-            NxPotentialsPerVth, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_xMax(runNum), H5T_NATIVE_DOUBLE, &
-            xMax, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_xMaxForDistribution(runNum), H5T_NATIVE_DOUBLE, &
-            xMaxForDistribution, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_solverTolerance(runNum), H5T_NATIVE_DOUBLE, &
-            solverTolerance, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Delta(runNum), H5T_NATIVE_DOUBLE, &
-            Delta, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_omega(runNum), H5T_NATIVE_DOUBLE, &
-            omega, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_psiAHat(runNum), H5T_NATIVE_DOUBLE, &
-            psiAHat, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_nu_r(runNum), H5T_NATIVE_DOUBLE, &
-            nu_r, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_Miller_q(runNum), H5T_NATIVE_DOUBLE, &
-            Miller_q, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_epsil(runNum), H5T_NATIVE_DOUBLE, &
-            epsil, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_psi(runNum), H5T_NATIVE_DOUBLE, &
-            psi, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_theta(runNum), H5T_NATIVE_DOUBLE, &
-            theta, dimForTheta(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_JHat(runNum), H5T_NATIVE_DOUBLE, &
-            JHat, dimForThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_BHat(runNum), H5T_NATIVE_DOUBLE, &
-            BHat, dimForThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dBHatdpsi(runNum), H5T_NATIVE_DOUBLE, &
-            dBHatdpsi, dimForThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dBHatdtheta(runNum), H5T_NATIVE_DOUBLE, &
-            dBHatdtheta, dimForThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_IHat(runNum), H5T_NATIVE_DOUBLE, &
-            IHat, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dIHatdpsi(runNum), H5T_NATIVE_DOUBLE, &
-            dIHatdpsi, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_PhiHat(runNum), H5T_NATIVE_DOUBLE, &
-            phiHat, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dPhiHatdpsi(runNum), H5T_NATIVE_DOUBLE, &
-            dPhiHatdpsi, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_THats(runNum), H5T_NATIVE_DOUBLE, &
-            THats, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dTHatdpsis(runNum), H5T_NATIVE_DOUBLE, &
-            dTHatdpsis, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_nHats(runNum), H5T_NATIVE_DOUBLE, &
-            nHats, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dnHatdpsis(runNum), H5T_NATIVE_DOUBLE, &
-            dnHatdpsis, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_etaHats(runNum), H5T_NATIVE_DOUBLE, &
-            etaHats, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_detaHatdpsis(runNum), H5T_NATIVE_DOUBLE, &
-            detaHatdpsis, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_elapsedTime(runNum), H5T_NATIVE_DOUBLE, &
-            elapsedTime, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_sourcePoloidalVariation(runNum), H5T_NATIVE_INTEGER, &
-            sourcePoloidalVariation, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_particleSourceProfile(runNum), H5T_NATIVE_DOUBLE, &
-            particleSourceProfile, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_heatSourceProfile(runNum), H5T_NATIVE_DOUBLE, &
-            heatSourceProfile, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_VPrimeHat(runNum), H5T_NATIVE_DOUBLE, &
-            VPrimeHat, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_FSABHat2(runNum), H5T_NATIVE_DOUBLE, &
-            FSABHat2, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_U(runNum), H5T_NATIVE_DOUBLE, &
-            U, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_r(runNum), H5T_NATIVE_DOUBLE, &
-            r, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_densityPerturbation(runNum), H5T_NATIVE_DOUBLE, &
-            densityPerturbation, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_flow(runNum), H5T_NATIVE_DOUBLE, &
-            flow, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_kPar(runNum), H5T_NATIVE_DOUBLE, &
-            kPar, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_pressurePerturbation(runNum), H5T_NATIVE_DOUBLE, &
-            pressurePerturbation, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_particleFluxBeforeThetaIntegral(runNum), H5T_NATIVE_DOUBLE, &
-            particleFluxBeforeThetaIntegral, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_momentumFluxBeforeThetaIntegral(runNum), H5T_NATIVE_DOUBLE, &
-            momentumFluxBeforeThetaIntegral, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_heatFluxBeforeThetaIntegral(runNum), H5T_NATIVE_DOUBLE, &
-            heatFluxBeforeThetaIntegral, dimForSpeciesThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_FSADensityPerturbation(runNum), H5T_NATIVE_DOUBLE, &
-            FSADensityPerturbation, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_flowOutboard(runNum), H5T_NATIVE_DOUBLE, &
-            flowOutboard, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_flowInboard(runNum), H5T_NATIVE_DOUBLE, &
-            flowInboard, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_FSABFlow(runNum), H5T_NATIVE_DOUBLE, &
-            FSABFlow, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_kParOutboard(runNum), H5T_NATIVE_DOUBLE, &
-            kParOutboard, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_kParInboard(runNum), H5T_NATIVE_DOUBLE, &
-            kParInboard, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_FSAKPar(runNum), H5T_NATIVE_DOUBLE, &
-            FSAKPar, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_FSAPressurePerturbation(runNum), H5T_NATIVE_DOUBLE, &
-            FSAPressurePerturbation, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-!!$       call h5dwrite_f(dsetIDs_LHSOfKParEquation(runNum), H5T_NATIVE_DOUBLE, &
-!!$            LHSOfKParEquation, dimForProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_particleFlux(runNum), H5T_NATIVE_DOUBLE, &
-            particleFlux, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_momentumFlux(runNum), H5T_NATIVE_DOUBLE, &
-            momentumFlux, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_heatFlux(runNum), H5T_NATIVE_DOUBLE, &
-            heatFlux, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       if (makeLocalApproximation) then
-          temp = integerToRepresentTrue
-       else
-          temp = integerToRepresentFalse
-       end if
-       call h5dwrite_f(dsetIDs_makeLocalApproximation(runNum), H5T_NATIVE_INTEGER, &
-            temp, dimForScalar, HDF5Error)
-
-       if (useIterativeSolver) then
-          temp = integerToRepresentTrue
-       else
-          temp = integerToRepresentFalse
-       end if
-       call h5dwrite_f(dsetIDs_useIterativeSolver(runNum), H5T_NATIVE_INTEGER, &
-            temp, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_didItConverge(runNum), H5T_NATIVE_INTEGER, &
-            didItConverge, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_psiDerivativeScheme(runNum), H5T_NATIVE_INTEGER, &
-            psiDerivativeScheme, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_thetaDerivativeScheme(runNum), H5T_NATIVE_INTEGER, &
-            thetaDerivativeScheme, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_xDerivativeScheme(runNum), H5T_NATIVE_INTEGER, &
-            xDerivativeScheme, dimForScalar, HDF5Error)
-
-!!$       call h5dwrite_f(dsetIDs_kThetaWith3PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaWith3PointStencil, dimForThetaPsi(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_kThetaWith5PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaWith5PointStencil, dimForThetaPsi(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_kThetaOutboardWith3PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaOutboardWith3PointStencil, dimForProfile(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_kThetaOutboardWith5PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaOutboardWith5PointStencil, dimForProfile(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_kThetaInboardWith3PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaInboardWith3PointStencil, dimForProfile(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_kThetaInboardWith5PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            kThetaInboardWith5PointStencil, dimForProfile(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_PhiTermInKTheta(runNum), H5T_NATIVE_DOUBLE, &
-!!$            PhiTermInKTheta, dimForThetaPsi(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_pPerpTermInKThetaBeforePsiDerivative(runNum), H5T_NATIVE_DOUBLE, &
-!!$            pPerpTermInKThetaBeforePsiDerivative, dimForThetaPsi(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_pPerpTermInKThetaWith3PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            pPerpTermInKThetaWith3PointStencil, dimForThetaPsi(runNum,:), HDF5Error)
-!!$
-!!$       call h5dwrite_f(dsetIDs_pPerpTermInKThetaWith5PointStencil(runNum), H5T_NATIVE_DOUBLE, &
-!!$            pPerpTermInKThetaWith5PointStencil, dimForThetaPsi(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_nuPrimeProfile(runNum), H5T_NATIVE_DOUBLE, &
-            nuPrimeProfile, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_nuStarProfile(runNum), H5T_NATIVE_DOUBLE, &
-            nuStarProfile, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_deltaN(runNum), H5T_NATIVE_DOUBLE, &
-            deltaN, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_deltaT(runNum), H5T_NATIVE_DOUBLE, &
-            deltaT, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_deltaEta(runNum), H5T_NATIVE_DOUBLE, &
-            deltaEta, dimForSpeciesProfile(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_desiredU(runNum), H5T_NATIVE_DOUBLE, &
-            desiredU, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_desiredFWHMInRhoTheta(runNum), H5T_NATIVE_DOUBLE, &
-            desiredFWHMInRhoTheta, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_exponent(runNum), H5T_NATIVE_DOUBLE, &
-            exponent, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_dTHatdpsiScalar(runNum), H5T_NATIVE_DOUBLE, &
-            dTHatdpsiScalar, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_detaHatdpsiScalar(runNum), H5T_NATIVE_DOUBLE, &
-            detaHatdpsiScalar, dimForScalar, HDF5Error)
-
-       if (setTPrimeToBalanceHeatFlux) then
-          temp = integerToRepresentTrue
-       else
-          temp = integerToRepresentFalse
-       end if
-       call h5dwrite_f(dsetIDs_setTPrimeToBalanceHeatFlux(runNum), H5T_NATIVE_INTEGER, &
-            temp, dimForScalar, HDF5Error)
-
-       if (includeddpsiTerm) then
-          temp = integerToRepresentTrue
-       else
-          temp = integerToRepresentFalse
-       end if
-       call h5dwrite_f(dsetIDs_includeddpsiTerm(runNum), H5T_NATIVE_INTEGER, &
-            temp, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_species(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_species, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_x(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_x, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_x_min_L(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_x_min_L, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_xi(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_xi, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_theta(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_theta, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_preconditioner_psi(runNum), H5T_NATIVE_INTEGER, &
-            preconditioner_psi, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_layout(runNum), H5T_NATIVE_INTEGER, &
-            layout, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_NxUniform(runNum), H5T_NATIVE_INTEGER, &
-            NxUniform, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_NxiUniform(runNum), H5T_NATIVE_INTEGER, &
-            NxiUniform, dimForScalar, HDF5Error)
-
-       call h5dwrite_f(dsetIDs_xUniform(runNum), H5T_NATIVE_DOUBLE, &
-            xUniform, dimForXUniform(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_xiUniform(runNum), H5T_NATIVE_DOUBLE, &
-            xiUniform, dimForXiUniform(runNum,:), HDF5Error)
-
-       call h5dwrite_f(dsetIDs_thetaIndexForOutboard(runNum), H5T_NATIVE_INTEGER, &
-            thetaIndexForOutboard, dimForScalar, HDF5Error)
-
-       if (outputScheme > 1) then
-          call h5dwrite_f(dsetIDs_deltaFOutboard(runNum), H5T_NATIVE_DOUBLE, &
-               deltaFOutboard, dimForSpeciesPsiXUniformXiUniform(runNum,:), HDF5Error)
-
-          call h5dwrite_f(dsetIDs_fullFOutboard(runNum), H5T_NATIVE_DOUBLE, &
-               fullFOutboard, dimForSpeciesPsiXUniformXiUniform(runNum,:), HDF5Error)
-       end if
+    if (outputScheme > 0) then
+
+      call writeVariable_1d_nonalloc(charges,"charges",runNum)
+      call writeVariable_1d_nonalloc(masses,"masses",runNum)
+      call writeVariable_1d_nonalloc(scalarTHats,"scalarTHats",runNum)
+      call writeVariable_1d_nonalloc(scalarNHats,"scalarNHats",runNum)
+      call writeVariable(NpsiPerDiameter,"NpsiPerDiameter",runNum)
+      call writeVariable(Npsi,"Npsi",runNum)
+      call writeVariable(psiDiameter,"psiDiameter",runNum)
+      call writeVariable(widthExtender,"widthExtender",runNum)
+      call writeVariable(numSpecies,"Nspecies",runNum)
+      call writeVariable(Ntheta,"Ntheta",runNum)
+      call writeVariable(Nxi,"Nxi",runNum)
+      call writeVariable(NL,"NL",runNum)
+      call writeVariable(Nx,"Nx",runNum)
+      call writeVariable(NxPotentialsPerVth,"NxPotentialsPerVth",runNum)
+      call writeVariable(xMax,"xMax",runNum)
+      call writeVariable(xMaxForDistribution,"xMaxForDistribution",runNum)
+      call writeVariable(solverTolerance,"solverTolerance",runNum)
+      call writeVariable(Delta,"Delta",runNum)
+      call writeVariable(omega,"omega",runNum)
+      call writeVariable(psiAHat,"psiAHat",runNum)
+      call writeVariable(nu_r,"nu_r",runNum)
+      call writeVariable(Miller_q,"Miller_q",runNum)
+      call writeVariable(epsil,"epsil",runNum)
+      call writeVariable(psi,"psi",runNum)
+      call writeVariable(theta,"theta",runNum)
+      call writeVariable(JHat,"JHat",runNum)
+      call writeVariable(BHat,"BHat",runNum)
+      call writeVariable(dBHatdpsi,"d(BHat)d(psi)",runNum)
+      call writeVariable(dBHatdtheta,"d(BHat)d(theta)",runNum)
+      call writeVariable(IHat,"IHat",runNum)
+      call writeVariable(dIHatdpsi,"d(IHat)d(psi)",runNum)
+      call writeVariable(PhiHat,"PhiHat",runNum)
+      call writeVariable(dPhiHatdpsi,"d(PhiHat)d(psi)",runNum)
+      call writeVariable(THats,"THat",runNum)
+      call writeVariable(dTHatdpsis,"d(THat)d(psi)",runNum)
+      call writeVariable(nHats,"nHat",runNum)
+      call writeVariable(dnHatdpsis,"d(nHat)d(psi)",runNum)
+      call writeVariable(etaHats,"etaHat",runNum)
+      call writeVariable(detaHatdpsis,"d(etaHat)d(psi)",runNum)
+      call writeVariable(elapsedTime,"elapsed time (s)",runNum)
+      call writeVariable(sourcePoloidalVariation,"sourcePoloidalVariation",runNum)
+      call writeVariable(particleSourceProfile,"particleSourceProfile",runNum)
+      call writeVariable(heatSourceProfile,"heatSourceProfile",runNum)
+      call writeVariable(VPrimeHat,"VPrimeHat",runNum)
+      call writeVariable(FSABHat2,"FSABHat2",runNum)
+      call writeVariable(U,"U",runNum)
+      call writeVariable(r,"r",runNum)
+      call writeVariable(densityPerturbation,"densityPerturbation",runNum)
+      call writeVariable(flow,"flow",runNum)
+      call writeVariable(kPar,"kPar",runNum)
+      call writeVariable(pressurePerturbation,"pressurePerturbation",runNum)
+      call writeVariable(particleFluxBeforeThetaIntegral,"particleFluxBeforeThetaIntegral",runNum)
+      call writeVariable(momentumFluxBeforeThetaIntegral,"momentumFluxBeforeThetaIntegral",runNum)
+      call writeVariable(heatFluxBeforeThetaIntegral,"heatFluxBeforeThetaIntegral",runNum)
+      call writeVariable(FSADensityPerturbation,"FSADensityPerturbation",runNum)
+      call writeVariable(flowOutboard,"flowOutboard",runNum)
+      call writeVariable(flowInboard,"flowInboard",runNum)
+      call writeVariable(FSABFlow,"FSABFlow",runNum)
+      call writeVariable(kParOutboard,"kParOutboard",runNum)
+      call writeVariable(kParInboard,"kParInboard",runNum)
+      call writeVariable(FSAKPar,"FSAKPar",runNum)
+      call writeVariable(FSAPressurePerturbation,"FSAPressurePerturbation",runNum)
+  !!$    call writeVariable(LHSOfKParEquation,"LHSOfKParEquation",runNum)
+      call writeVariable(particleFlux,"particleFlux",runNum)
+      call writeVariable(momentumFlux,"momentumFlux",runNum)
+      call writeVariable(heatFlux,"heatFlux",runNum)
+      if (makeLocalApproximation) then
+         temp = integerToRepresentTrue
+      else
+         temp = integerToRepresentFalse
+      end if
+      call writeVariable(temp,"makeLocalApproximation",runNum)
+      if (useIterativeSolver) then
+         temp = integerToRepresentTrue
+      else
+         temp = integerToRepresentFalse
+      end if
+      call writeVariable(temp,"useIterativeSolver",runNum)
+      call writeVariable(didItConverge,"didItConverge",runNum)
+      call writeVariable(psiDerivativeScheme,"psiDerivativeScheme",runNum)
+      call writeVariable(thetaDerivativeScheme,"thetaDerivativeScheme",runNum)
+      call writeVariable(xDerivativeScheme,"xDerivativeScheme",runNum)
+  !!$    call writeVariable(kThetaWith3PointStencil,"kThetaWith3PointStencil",runNum)
+  !!$    call writeVariable(kThetaWith5PointStencil,"kThetaWith5PointStencil",runNum)
+  !!$    call writeVariable(kThetaOutboardWith3PointStencil,"kThetaOutboardWith3PointStencil",runNum)
+  !!$    call writeVariable(kThetaOutboardWith5PointStencil,"kThetaOutboardWith5PointStencil",runNum)
+  !!$    call writeVariable(kThetaInboardWith3PointStencil,"kThetaInboardWith3PointStencil",runNum)
+  !!$    call writeVariable(kThetaInboardWith5PointStencil,"kThetaInboardWith5PointStencil",runNum)
+  !!$    call writeVariable(PhiTermInKTheta,"PhiTermInKTheta",runNum)
+  !!$    call writeVariable(pPerpTermInKThetaBeforePsiDerivative,"pPerpTermInKThetaBeforePsiDerivative",runNum)
+  !!$    call writeVariable(pPerpTermInKThetaWith3PointStencil,"pPerpTermInKThetaWith3PointStencil",runNum)
+  !!$    call writeVariable(pPerpTermInKThetaWith5PointStencil,"pPerpTermInKThetaWith5PointStencil",runNum)
+      call writeVariable(nuPrimeProfile,"nuPrimeProfile",runNum)
+      call writeVariable(nuStarProfile,"nuStarProfile",runNum)
+      call writeVariable(deltaN,"deltaN",runNum)
+      call writeVariable(deltaT,"deltaT",runNum)
+      call writeVariable(deltaEta,"deltaEta",runNum)
+      call writeVariable(desiredU,"desiredU",runNum)
+      call writeVariable(desiredFWHMInRhoTheta,"desiredFWHMInRhoTheta",runNum)
+      call writeVariable(dTHatdpsiScalar,"dTHatdpsiScalar",runNum)
+      call writeVariable(detaHatdpsiScalar,"detaHatdpsiScalar",runNum)
+      call writeVariable(exponent,"exponent",runNum)
+      if (setTPrimeToBalanceHeatFlux) then
+         temp = integerToRepresentTrue
+      else
+         temp = integerToRepresentFalse
+      end if
+      call writeVariable(temp,"setTPrimeToBalanceHeatFlux",runNum)
+      if (includeddpsiTerm) then
+         temp = integerToRepresentTrue
+      else
+         temp = integerToRepresentFalse
+      end if
+      call writeVariable(temp,"includeddpsiTerm",runNum)
+      call writeVariable(preconditioner_species,"preconditioner_species",runNum)
+      call writeVariable(preconditioner_x,"preconditioner_x",runNum)
+      call writeVariable(preconditioner_x_min_L,"preconditioner_x_min_L",runNum)
+      call writeVariable(preconditioner_xi,"preconditioner_xi",runNum)
+      call writeVariable(preconditioner_theta,"preconditioner_theta",runNum)
+      call writeVariable(preconditioner_psi,"preconditioner_psi",runNum)
+      call writeVariable(layout,"layout",runNum)
+      call writeVariable(NxUniform,"NxUniform",runNum)
+      call writeVariable(NxiUniform,"NxiUniform",runNum)
+      call writeVariable(xUniform,"xUniform",runNum)
+      call writeVariable(xiUniform,"xiUniform",runNum)
+      call writeVariable(thetaIndexForOutboard,"thetaIndexForOutboard",runNum)
+      if (outputScheme > 1) then
+        call writeVariable(deltaFOutboard,"deltaFOutboard",runNum)
+        call writeVariable(fullFOutboard,"fullFOutboard",runNum)
+      end if
     end if
 
   end subroutine writeRunToOutputFile
 
-  ! -----------------------------------------------------------------------------------
+    ! -----------------------------------------------------------------------------------
 
   subroutine closeOutputFile()
 
@@ -1103,128 +260,9 @@ contains
        if (outputScheme > 0 .and. masterProcInSubComm) then
 #endif
        do i=1,numRunsInScan
-          call h5dclose_f(dsetIDs_charges(i), HDF5Error)
-          call h5dclose_f(dsetIDs_masses(i), HDF5Error)
-          call h5dclose_f(dsetIDs_scalarTHats(i), HDF5Error)
-          call h5dclose_f(dsetIDs_scalarNHats(i), HDF5Error)
-          call h5dclose_f(dsetIDs_NpsiPerDiameter(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Npsi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_psiDiameter(i), HDF5Error)
-          call h5dclose_f(dsetIDs_widthExtender(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Nspecies(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Ntheta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Nxi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_NL(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Nx(i), HDF5Error)
-          call h5dclose_f(dsetIDs_NxPotentialsPerVth(i), HDF5Error)
-          call h5dclose_f(dsetIDs_xMax(i), HDF5Error)
-          call h5dclose_f(dsetIDs_xMaxForDistribution(i), HDF5Error)
-          call h5dclose_f(dsetIDs_solverTolerance(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Delta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_omega(i), HDF5Error)
-          call h5dclose_f(dsetIDs_psiAHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_nu_r(i), HDF5Error)
-          call h5dclose_f(dsetIDs_Miller_q(i), HDF5Error)
-          call h5dclose_f(dsetIDs_epsil(i), HDF5Error)
-          call h5dclose_f(dsetIDs_psi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_theta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_JHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_BHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dBHatdpsi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dBHatdtheta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_IHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dIHatdpsi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_PhiHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dPhiHatdpsi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_THats(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dTHatdpsis(i), HDF5Error)
-          call h5dclose_f(dsetIDs_nHats(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dnHatdpsis(i), HDF5Error)
-          call h5dclose_f(dsetIDs_etaHats(i), HDF5Error)
-          call h5dclose_f(dsetIDs_detaHatdpsis(i), HDF5Error)
-          call h5dclose_f(dsetIDs_elapsedTime(i), HDF5Error)
-          call h5dclose_f(dsetIDs_sourcePoloidalVariation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_particleSourceProfile(i), HDF5Error)
-          call h5dclose_f(dsetIDs_heatSourceProfile(i), HDF5Error)
-          call h5dclose_f(dsetIDs_VPrimeHat(i), HDF5Error)
-          call h5dclose_f(dsetIDs_FSABHat2(i), HDF5Error)
-          call h5dclose_f(dsetIDs_U(i), HDF5Error)
-          call h5dclose_f(dsetIDs_r(i), HDF5Error)
-          call h5dclose_f(dsetIDs_densityPerturbation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_flow(i), HDF5Error)
-          call h5dclose_f(dsetIDs_kPar(i), HDF5Error)
-          call h5dclose_f(dsetIDs_pressurePerturbation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_particleFluxBeforeThetaIntegral(i), HDF5Error)
-          call h5dclose_f(dsetIDs_momentumFluxBeforeThetaIntegral(i), HDF5Error)
-          call h5dclose_f(dsetIDs_heatFluxBeforeThetaIntegral(i), HDF5Error)
-          call h5dclose_f(dsetIDs_FSADensityPerturbation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_flowOutboard(i), HDF5Error)
-          call h5dclose_f(dsetIDs_flowInboard(i), HDF5Error)
-          call h5dclose_f(dsetIDs_FSABFlow(i), HDF5Error)
-          call h5dclose_f(dsetIDs_kParOutboard(i), HDF5Error)
-          call h5dclose_f(dsetIDs_kParInboard(i), HDF5Error)
-          call h5dclose_f(dsetIDs_FSAKPar(i), HDF5Error)
-          call h5dclose_f(dsetIDs_FSAPressurePerturbation(i), HDF5Error)
-!          call h5dclose_f(dsetIDs_LHSOfKParEquation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_particleFlux(i), HDF5Error)
-          call h5dclose_f(dsetIDs_momentumFlux(i), HDF5Error)
-          call h5dclose_f(dsetIDs_heatFlux(i), HDF5Error)
-          call h5dclose_f(dsetIDs_makeLocalApproximation(i), HDF5Error)
-          call h5dclose_f(dsetIDs_useIterativeSolver(i), HDF5Error)
-          call h5dclose_f(dsetIDs_didItConverge(i), HDF5Error)
-          call h5dclose_f(dsetIDs_psiDerivativeScheme(i), HDF5Error)
-          call h5dclose_f(dsetIDs_thetaDerivativeScheme(i), HDF5Error)
-          call h5dclose_f(dsetIDs_xDerivativeScheme(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaWith3PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaWith5PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaOutboardWith3PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaOutboardWith5PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaInboardWith3PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_kThetaInboardWith5PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_PhiTermInKTheta(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_pPerpTermInKThetaBeforePsiDerivative(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_pPerpTermInKThetaWith3PointStencil(i), HDF5Error)
-!!$          call h5dclose_f(dsetIDs_pPerpTermInKThetaWith5PointStencil(i), HDF5Error)
-          call h5dclose_f(dsetIDs_nuPrimeProfile(i), HDF5Error)
-          call h5dclose_f(dsetIDs_nuStarProfile(i), HDF5Error)
-          call h5dclose_f(dsetIDs_deltaN(i), HDF5Error)
-          call h5dclose_f(dsetIDs_deltaT(i), HDF5Error)
-          call h5dclose_f(dsetIDs_deltaEta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_desiredU(i), HDF5Error)
-          call h5dclose_f(dsetIDs_desiredFWHMInRhoTheta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_setTPrimeToBalanceHeatFlux(i), HDF5Error)
-          call h5dclose_f(dsetIDs_exponent(i), HDF5Error)
-          call h5dclose_f(dsetIDs_dTHatdpsiScalar(i), HDF5Error)
-          call h5dclose_f(dsetIDs_detaHatdpsiScalar(i), HDF5Error)
-          call h5dclose_f(dsetIDs_includeddpsiTerm(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_species(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_x(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_x_min_L(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_xi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_theta(i), HDF5Error)
-          call h5dclose_f(dsetIDs_preconditioner_psi(i), HDF5Error)
-          call h5dclose_f(dsetIDs_layout(i), HDF5Error)
-          call h5dclose_f(dsetIDs_NxUniform(i), HDF5Error)
-          call h5dclose_f(dsetIDs_NxiUniform(i), HDF5Error)
-          call h5dclose_f(dsetIDs_xUniform(i), HDF5Error)
-          call h5dclose_f(dsetIDs_xiUniform(i), HDF5Error)
-          call h5dclose_f(dsetIDs_thetaIndexForOutboard(i), HDF5Error)
-          if (outputScheme > 1) then
-             call h5dclose_f(dsetIDs_deltaFOutboard(i), HDF5Error)
-             call h5dclose_f(dsetIDs_fullFOutboard(i), HDF5Error)
-          end if
-
           call h5gclose_f(groupIDs(i), HDF5Error)
-
-!          call h5sclose_f(dspaceIDForSpecies(i), HDF5Error)
-!          call h5sclose_f(dspaceIDForProfile(i), HDF5Error)
-!          call h5sclose_f(dspaceIDForSpeciesProfile(i), HDF5Error)
-!          call h5sclose_f(dspaceIDForTheta(i), HDF5Error)
-!          call h5sclose_f(dspaceIDForThetaPsi(i), HDF5Error)
-!          call h5sclose_f(dspaceIDForSpeciesThetaPsi(i), HDF5Error)
        end do
 
-       call h5sclose_f(dspaceIDForScalar, HDF5Error)
        call h5pclose_f(parallelID, HDF5Error)
        call h5fclose_f(HDF5FileID, HDF5Error)
        call h5close_f(HDF5Error)
@@ -1232,15 +270,305 @@ contains
 
   end subroutine closeOutputFile
 
+  subroutine writeVariable_scalar(var, varname, i)
+
+    PetscScalar, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(0) :: dimensions
+
+    dimensions = shape(var)
+
+#ifdef HAVE_PARALLEL_HDF5
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_scalar
+
+  subroutine writeVariable_integer(var, varname, i)
+
+    integer, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(0) :: dimensions
+
+    dimensions = shape(var)
+
+#ifdef HAVE_PARALLEL_HDF5
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_integer
+
+  subroutine writeVariable_1d(var, varname, i)
+
+    PetscScalar, dimension(:), allocatable, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(1) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_1d
+
+  subroutine writeVariable_1d_nonalloc(var, varname, i)
+
+    PetscScalar, dimension(:), intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(1) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_1d_nonalloc
+
+  subroutine writeVariable_2d(var, varname, i)
+
+    PetscScalar, dimension(:,:), allocatable, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(2) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_2d
+
+  subroutine writeVariable_3d(var, varname, i)
+
+    PetscScalar, dimension(:,:,:), allocatable, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(3) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_3d
+
+  subroutine writeVariable_4d(var, varname, i)
+
+    PetscScalar, dimension(:,:,:,:), allocatable, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(4) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_4d
+
+  subroutine writeVariable_5d(var, varname, i)
+
+    PetscScalar, dimension(:,:,:,:,:), allocatable, intent(in) :: var
+    integer, intent(in) :: i
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(5) :: dimensions
+    integer :: ierror
+
+#ifdef HAVE_PARALLEL_HDF5
+    if (masterProcInSubComm) then
+      dimensions = shape(var)
+    end if
+    call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    if (masterProcInSubComm) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProcInSubComm) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeVariable_5d
+
+  subroutine writeIntegerNoGroup(var,varname)
+    ! Only writes on masterProc
+
+    Integer, intent(in) :: var
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(0) :: dimensions
+    integer :: ierror
+
+    dimensions = shape(var)
+
+#ifdef HAVE_PARALLEL_HDF5
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(HDF5FileID, varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
+    if (masterProc) then
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
+    end if
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+#else
+    if (masterProc) then
+      call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+      call h5dcreate_f(HDF5FileID, varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
+      call h5dclose_f(dsetID, HDF5Error)
+      call h5sclose_f(dspaceID, HDF5Error)
+    end if
+#endif
+
+  end subroutine writeIntegerNoGroup
+
   subroutine openDebugOutputFile(filename)
 
     character(len=*), intent(in) :: filename
 
-!#ifdef HAVE_PARALLEL_HDF5
-!    if (outputScheme > 0) then
-!#else
-!    if (outputScheme > 0 .and. masterProcInSubComm) then
-!#endif
+  !#ifdef HAVE_PARALLEL_HDF5
+  !    if (outputScheme > 0) then
+  !#else
+  !    if (outputScheme > 0 .and. masterProcInSubComm) then
+  !#endif
       !print *, "opening",filename
       call h5open_f(HDF5Error)
       if (HDF5Error < 0) then
@@ -1248,21 +576,21 @@ contains
          stop
       end if
 
-!#ifdef HAVE_PARALLEL_HDF5
-!       ! Initialize some stuff related to parallel file access
-!       call h5pcreate_f(H5P_FILE_ACCESS_F, parallelID, HDF5Error)
-!       call h5pset_fapl_mpio_f(parallelID, MPI_COMM_WORLD, MPI_INFO_NULL, HDF5Error)
-!
-!       call h5fcreate_f(filename, H5F_ACC_TRUNC_F, HDF5DebugFileID, HDF5Error, access_prp=parallelID)
-!#else
+  !#ifdef HAVE_PARALLEL_HDF5
+  !       ! Initialize some stuff related to parallel file access
+  !       call h5pcreate_f(H5P_FILE_ACCESS_F, parallelID, HDF5Error)
+  !       call h5pset_fapl_mpio_f(parallelID, MPI_COMM_WORLD, MPI_INFO_NULL, HDF5Error)
+  !
+  !       call h5fcreate_f(filename, H5F_ACC_TRUNC_F, HDF5DebugFileID, HDF5Error, access_prp=parallelID)
+  !#else
        call h5fcreate_f(filename, H5F_ACC_TRUNC_F, HDF5DebugFileID, HDF5Error)
-!#endif
+  !#endif
        if (HDF5Error < 0) then
           print *,"Error opening HDF5 output file."
           stop
        end if
 
-!    end if
+  !    end if
 
   end subroutine openDebugOutputFile
 
@@ -1281,8 +609,6 @@ contains
     character(len=*), intent(in) :: varname
     integer(HID_T) :: dspaceID, dsetID
     integer(HSIZE_T), dimension(:), allocatable :: dimensions
-
-    !print *,"writing",varname
 
     dimensions = shape(var)
 
@@ -1303,7 +629,6 @@ contains
 
     dimensions = shape(var)
 
-    !print *,"writing",varname
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
     call h5dcreate_f(HDF5DebugFileID, varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
     call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
@@ -1321,7 +646,6 @@ contains
 
     dimensions = shape(var)
 
-    !print *,"writing",varname
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
     call h5dcreate_f(HDF5DebugFileID, varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
     call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
@@ -1339,7 +663,6 @@ contains
 
     dimensions = shape(var)
 
-    !print *,"writing",varname
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
     call h5dcreate_f(HDF5DebugFileID, varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
     call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
@@ -1357,7 +680,6 @@ contains
 
     dimensions = shape(var)
 
-    !print *,"writing",varname
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
     call h5dcreate_f(HDF5DebugFileID, varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
     call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
@@ -1365,6 +687,23 @@ contains
     call h5sclose_f(dspaceID, HDF5Error)
 
   end subroutine writeDebugArray_4d
+
+  subroutine writeDebugArray_5d(var,varname)
+
+    PetscScalar, dimension(:,:,:,:,:), allocatable, intent(in) :: var
+    character(len=*), intent(in) :: varname
+    integer(HID_T) :: dspaceID, dsetID
+    integer(HSIZE_T), dimension(:), allocatable :: dimensions
+
+    dimensions = shape(var)
+
+    call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
+    call h5dcreate_f(HDF5DebugFileID, varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+    call h5dclose_f(dsetID, HDF5Error)
+    call h5sclose_f(dspaceID, HDF5Error)
+
+  end subroutine writeDebugArray_5d
 
 end module writeHDF5Output
 

--- a/fortran/writeHDF5Output.F90
+++ b/fortran/writeHDF5Output.F90
@@ -111,10 +111,10 @@ contains
 
     if (outputScheme > 0) then
 
-      call writeVariable_1d_nonalloc(charges,"charges",runNum)
-      call writeVariable_1d_nonalloc(masses,"masses",runNum)
-      call writeVariable_1d_nonalloc(scalarTHats,"scalarTHats",runNum)
-      call writeVariable_1d_nonalloc(scalarNHats,"scalarNHats",runNum)
+      call writeVariable_1d_nonalloc(charges,numSpecies,"charges",runNum)
+      call writeVariable_1d_nonalloc(masses,numSpecies,"masses",runNum)
+      call writeVariable_1d_nonalloc(scalarTHats,numSpecies,"scalarTHats",runNum)
+      call writeVariable_1d_nonalloc(scalarNHats,numSpecies,"scalarNHats",runNum)
       call writeVariable(NpsiPerDiameter,"NpsiPerDiameter",runNum)
       call writeVariable(Npsi,"Npsi",runNum)
       call writeVariable(psiDiameter,"psiDiameter",runNum)
@@ -312,17 +312,17 @@ contains
 
 #ifdef HAVE_PARALLEL_HDF5
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
-    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+    call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
     if (masterProcInSubComm) then
-      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
     end if
     call h5dclose_f(dsetID, HDF5Error)
     call h5sclose_f(dspaceID, HDF5Error)
 #else
     if (masterProcInSubComm) then
       call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
-      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER dspaceID, dsetID, HDF5Error)
-      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER var, dimensions, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
       call h5dclose_f(dsetID, HDF5Error)
       call h5sclose_f(dspaceID, HDF5Error)
     end if
@@ -355,8 +355,8 @@ contains
     if (masterProcInSubComm) then
       dimensions = shape(var)
       call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)
-      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_INTEGER, dspaceID, dsetID, HDF5Error)
-      call h5dwrite_f(dsetID, H5T_NATIVE_INTEGER, var, dimensions, HDF5Error)
+      call h5dcreate_f(groupIDs(i), varname, H5T_NATIVE_DOUBLE, dspaceID, dsetID, HDF5Error)
+      call h5dwrite_f(dsetID, H5T_NATIVE_DOUBLE, var, dimensions, HDF5Error)
       call h5dclose_f(dsetID, HDF5Error)
       call h5sclose_f(dspaceID, HDF5Error)
     end if
@@ -364,10 +364,10 @@ contains
 
   end subroutine writeVariable_1d
 
-  subroutine writeVariable_1d_nonalloc(var, varname, i)
+  subroutine writeVariable_1d_nonalloc(var, varsize, varname, i)
 
     PetscScalar, dimension(:), intent(in) :: var
-    integer, intent(in) :: i
+    integer, intent(in) :: varsize, i
     character(len=*), intent(in) :: varname
     integer(HID_T) :: dspaceID, dsetID
     integer(HSIZE_T), dimension(1) :: dimensions
@@ -375,7 +375,7 @@ contains
 
 #ifdef HAVE_PARALLEL_HDF5
     if (masterProcInSubComm) then
-      dimensions = shape(var)
+      dimensions = varsize
     end if
     call MPI_Bcast(dimensions,2*size(dimensions),MPI_INTEGER,0,MPIComm,ierror) ! 2*size(dimensions) since there seems to be no MPI datatype for long integers in Fortran, while the HSIZE_T kind is a long integer
     call h5screate_simple_f(rank(var), dimensions, dspaceID, HDF5Error)


### PR DESCRIPTION
Restructure HDF5 input and output to use helper functions through interfaces readVariable and writeVariable instead of explicit calls to HDF5 subroutines. Makes it easier to add new inputs or outputs.
